### PR TITLE
fix: segment type changed in koishi 4.9

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -111,7 +111,10 @@ export class Search extends Service {
     }
   }
 
-  async render(macro: { name: string; description: string }, about: string): Promise<string> {
+  async render(
+    macro: { name: string; description: string },
+    about: string,
+  ): Promise<ReturnType<typeof segment['image']>> {
     const { puppeteer } = this.ctx
 
     if (!puppeteer) {


### PR DESCRIPTION
Fix #31
Koishi v4.9 changed the return type to `Element` instead of `string`, but we should maintain current backward compatiable. So the better way is to using the `ReturnType` type helper.