### PR TITLE
refactor: migrate hint to use koishi suggest plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "peerDependencies": {
     "@koishijs/plugin-puppeteer": "^3.2.0",
+    "@koishijs/plugin-suggest": "*",
     "koishi": "^4.7.6"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Context } from 'koishi'
+import type {} from '@koishijs/plugin-suggest'
 
 import { Config } from './config'
 import i18n from './i18n'
@@ -71,8 +72,12 @@ export async function apply(ctx: Context, _config: Config): Promise<void> {
         return session?.text('.not_found_macro')
       }
 
-      if (db.exactly) {
-        session?.text('.hint', [db.name])
+      if (!db.exactly) {
+        session?.suggest({
+          prefix: session?.text('.hint', [db.name]),
+          suffix: session?.text('.hint_suffix'),
+          apply: (suggestion, next) => {},
+        })
       }
 
       const imageMode = (session?.channel?.macrodict?.mode ?? config.defaultMode) === 'auto' ? !!ctx.puppeteer : false


### PR DESCRIPTION
It would be better to split the fuzzy search feature to use the [`koishi suggest plugin`](https://github.com/koishijs/koishi/tree/master/plugins/a11y/suggest)